### PR TITLE
Add bulk_control_device method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ reqwest = {version = "0.11.14", features = ["blocking", "json"]}
 serde = {version = "1.0.154", features = ["derive"]}
 serde_json = "1.0.94"
 lazy_static = "1.4.0"
-tokio = {version = "1.32.0", features = ["full"]}
 futures = "0.3"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "govee-api"
 authors = ["Maciej Gierada"]
-version = "1.1.1"
+version = "1.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["govee", "api", "wrapper", "client", "sdk"]
@@ -19,6 +19,7 @@ serde = {version = "1.0.154", features = ["derive"]}
 serde_json = "1.0.94"
 lazy_static = "1.4.0"
 tokio = {version = "1.32.0", features = ["full"]}
+futures = "0.3"
 
 [dev-dependencies]
 tokio = {version = "1.32.0", features = ["full"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ reqwest = {version = "0.11.14", features = ["blocking", "json"]}
 serde = {version = "1.0.154", features = ["derive"]}
 serde_json = "1.0.94"
 lazy_static = "1.4.0"
+tokio = {version = "1.32.0", features = ["full"]}
 
 [dev-dependencies]
-tokio = {version = "1.28.2", features = ["full"]}
+tokio = {version = "1.32.0", features = ["full"]}
 mockito = "1.1.0"

--- a/src/api/api.rs
+++ b/src/api/api.rs
@@ -56,7 +56,7 @@ impl GoveeClient {
             .iter()
             .map(|payload| {
                 let payload_json = json!(payload);
-                let endpoint= endpoint.clone();
+                let endpoint = endpoint.clone();
                 let govee_api_key = self.govee_api_key.to_string();
                 let client = client.clone();
 
@@ -73,14 +73,8 @@ impl GoveeClient {
         let results = futures::future::join_all(requests).await;
         for result in results {
             match result {
-                Ok(res) => {
-                    // Process the response if needed
-                    println!("Response: {:?}", res);
-                }
-                Err(err) => {
-                    // Handle the error
-                    eprintln!("Error: {:?}", err);
-                }
+                Ok(_) => (),
+                Err(err) => return Err(err),
             }
         }
         Ok(())

--- a/src/api/api.rs
+++ b/src/api/api.rs
@@ -45,6 +45,31 @@ impl GoveeClient {
     }
 }
 
+/// Asynchronously controls multiple devices by sending payloads to the Govee API.
+///
+/// This method takes a vector of `PayloadBody` objects and sends control requests to the Govee API
+/// for each payload asynchronously. It uses the provided `self.govee_api_key` and `self.govee_root_url`
+/// to construct the API endpoint for each request.
+///
+/// # Arguments
+///
+/// - `payloads`: A vector of `PayloadBody` objects representing the control payloads for the devices.
+///
+/// # Returns
+///
+/// Returns a `Result` indicating success or an error that occurred during the requests.
+///
+/// # Examples
+///
+/// ```rust
+/// let govee_client = GoveeClient::new("your_api_key", "https://api.govee.com");
+/// let payloads = vec![payload1, payload2];
+/// let result = govee_client.bulk_control_devices(payloads).await;
+/// match result {
+///     Ok(_) => println!("Devices controlled successfully"),
+///     Err(err) => eprintln!("Error controlling devices: {:?}", err),
+/// }
+/// `
 impl GoveeClient {
     pub async fn bulk_control_devices(
         &self,
@@ -59,7 +84,6 @@ impl GoveeClient {
                 let endpoint = endpoint.clone();
                 let govee_api_key = self.govee_api_key.to_string();
                 let client = client.clone();
-
                 async move {
                     client
                         .put(&endpoint)

--- a/src/api/api.rs
+++ b/src/api/api.rs
@@ -1,8 +1,6 @@
 use reqwest::Error as ReqwestError;
 use reqwest::{Client, Url};
 use serde_json::json;
-// use std::error::Error;
-// use std::fmt;
 
 use crate::{
     structs::govee::{
@@ -47,25 +45,6 @@ impl GoveeClient {
     }
 }
 
-// #[derive(Debug)]
-// pub struct GoveeClientError {
-//     errors: Vec<ReqwestError>,
-// }
-
-// impl GoveeClientError {
-//     fn new(errors: Vec<ReqwestError>) -> Self {
-//         GoveeClientError { errors }
-//     }
-// }
-
-// impl fmt::Display for GoveeClientError {
-//     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-//         write!(f, "GoveeClientError: {} errors", self.errors.len())
-//     }
-// }
-//
-// impl Error for GoveeClientError {}
-
 impl GoveeClient {
     pub async fn bulk_control_devices(
         &self,
@@ -73,7 +52,6 @@ impl GoveeClient {
     ) -> Result<(), ReqwestError> {
         let client = Client::new();
         let endpoint = format!("{}/v1/devices/control", &self.govee_root_url);
-
         let requests = payloads
             .iter()
             .map(|payload| {
@@ -92,9 +70,7 @@ impl GoveeClient {
                 }
             })
             .collect::<Vec<_>>();
-
         let results = futures::future::join_all(requests).await;
-
         for result in results {
             match result {
                 Ok(res) => {
@@ -107,70 +83,9 @@ impl GoveeClient {
                 }
             }
         }
-
         Ok(())
     }
 }
-
-// #[derive(IntoIterator)]
-// pub struct BulkPayloadBody {
-//     pub payloads: Vec<PayloadBody>,
-// }
-
-// impl GoveeClient {
-//     pub async fn bulk_control_device(
-//         &self,
-//         payloads: Vec<PayloadBody>,
-//     ) -> Result<(), GoveeClientError> {
-//         let (tx, mut rx) = mpsc::channel(32); // Adjust the channel capacity as needed
-//         let client = Client::new();
-//
-//         // Create an Arc containing the payloads
-//         let payloads_arc = Arc::new(payloads);
-//         // let self_arc = Arc::new(self.clone());
-//         let self_clone = self.clone();
-//
-//         for payload in payloads_arc.iter() {
-//             // let self_clone = Arc::clone(&self_clone); // Clone self for each iteration
-//             let tx_clone = tx.clone();
-//
-//             let payload_clone = payload.clone(); // Clone the individual payload
-//
-//             tokio::spawn(async move {
-//                 // match self_clone.control_device(payload_clone).await {
-//                 match self_clone.control_device(payload_clone).await {
-//                     Ok(_) => {
-//                         // Send a message to the receiver indicating success
-//                         if tx_clone.send(Ok(())).await.is_err() {
-//                             eprintln!("Failed to send result to the receiver");
-//                         }
-//                     }
-//                     Err(err) => {
-//                         // Send an error message to the receiver
-//                         if tx_clone.send(Err(err)).await.is_err() {
-//                             eprintln!("Failed to send result to the receiver");
-//                         }
-//                     }
-//                 }
-//             });
-//         }
-//
-//         // Collect and handle results
-//         let mut errors = vec![];
-//         for _ in 0..payloads_arc.len() {
-//             match rx.recv().await.unwrap() {
-//                 Ok(_) => {}
-//                 Err(err) => errors.push(err),
-//             }
-//         }
-//
-//         if errors.is_empty() {
-//             Ok(())
-//         } else {
-//             Err(GoveeClientError::new(errors))
-//         }
-//     }
-// }
 
 /// Controls a Govee appliance using the provided payload.
 ///

--- a/src/api/api.rs
+++ b/src/api/api.rs
@@ -1,10 +1,8 @@
 use reqwest::Error as ReqwestError;
 use reqwest::{Client, Url};
 use serde_json::json;
-use std::error::Error;
-use std::fmt;
-use std::sync::Arc;
-use tokio::sync::mpsc;
+// use std::error::Error;
+// use std::fmt;
 
 use crate::{
     structs::govee::{
@@ -49,82 +47,130 @@ impl GoveeClient {
     }
 }
 
-#[derive(Debug)]
-pub struct GoveeClientError {
-    errors: Vec<ReqwestError>,
-}
+// #[derive(Debug)]
+// pub struct GoveeClientError {
+//     errors: Vec<ReqwestError>,
+// }
 
-impl GoveeClientError {
-    fn new(errors: Vec<ReqwestError>) -> Self {
-        GoveeClientError { errors }
+// impl GoveeClientError {
+//     fn new(errors: Vec<ReqwestError>) -> Self {
+//         GoveeClientError { errors }
+//     }
+// }
+
+// impl fmt::Display for GoveeClientError {
+//     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+//         write!(f, "GoveeClientError: {} errors", self.errors.len())
+//     }
+// }
+//
+// impl Error for GoveeClientError {}
+
+impl GoveeClient {
+    pub async fn bulk_control_devices(
+        &self,
+        payloads: Vec<PayloadBody>,
+    ) -> Result<(), ReqwestError> {
+        let client = Client::new();
+        let endpoint = format!("{}/v1/devices/control", &self.govee_root_url);
+
+        let requests = payloads
+            .iter()
+            .map(|payload| {
+                let payload_json = json!(payload);
+                let endpoint= endpoint.clone();
+                let govee_api_key = self.govee_api_key.to_string();
+                let client = client.clone();
+
+                async move {
+                    client
+                        .put(&endpoint)
+                        .header("Govee-API-Key", &govee_api_key)
+                        .json(&payload_json)
+                        .send()
+                        .await
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let results = futures::future::join_all(requests).await;
+
+        for result in results {
+            match result {
+                Ok(res) => {
+                    // Process the response if needed
+                    println!("Response: {:?}", res);
+                }
+                Err(err) => {
+                    // Handle the error
+                    eprintln!("Error: {:?}", err);
+                }
+            }
+        }
+
+        Ok(())
     }
 }
-
-impl fmt::Display for GoveeClientError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "GoveeClientError: {} errors", self.errors.len())
-    }
-}
-
-impl Error for GoveeClientError {}
 
 // #[derive(IntoIterator)]
 // pub struct BulkPayloadBody {
 //     pub payloads: Vec<PayloadBody>,
 // }
 
-impl GoveeClient {
-pub async fn bulk_control_device(
-        &self,
-        payloads: Vec<PayloadBody>,
-    ) -> Result<(), GoveeClientError> {
-        let (tx, mut rx) = mpsc::channel(32); // Adjust the channel capacity as needed
-        let client = Client::new();
-        
-        // Create an Arc containing the payloads
-        let payloads_arc = Arc::new(payloads);
-        let self_arc = Arc::new(self.clone());
-
-        for payload in payloads_arc.iter() {
-            let self_clone = Arc::clone(&self_arc);
-            let tx_clone = tx.clone();
-
-            let payload_clone = payload.clone(); // Clone the individual payload
-
-            tokio::spawn(async move {
-                match self_clone.control_device(payload_clone).await {
-                    Ok(_) => {
-                        // Send a message to the receiver indicating success
-                        if tx_clone.send(Ok(())).await.is_err() {
-                            eprintln!("Failed to send result to the receiver");
-                        }
-                    }
-                    Err(err) => {
-                        // Send an error message to the receiver
-                        if tx_clone.send(Err(err)).await.is_err() {
-                            eprintln!("Failed to send result to the receiver");
-                        }
-                    }
-                }
-            });
-        }
-
-        // Collect and handle results
-        let mut errors = vec![];
-        for _ in 0..payloads_arc.len() {
-            match rx.recv().await.unwrap() {
-                Ok(_) => {}
-                Err(err) => errors.push(err),
-            }
-        }
-
-        if errors.is_empty() {
-            Ok(())
-        } else {
-            Err(GoveeClientError::new(errors))
-        }
-    }
-}
+// impl GoveeClient {
+//     pub async fn bulk_control_device(
+//         &self,
+//         payloads: Vec<PayloadBody>,
+//     ) -> Result<(), GoveeClientError> {
+//         let (tx, mut rx) = mpsc::channel(32); // Adjust the channel capacity as needed
+//         let client = Client::new();
+//
+//         // Create an Arc containing the payloads
+//         let payloads_arc = Arc::new(payloads);
+//         // let self_arc = Arc::new(self.clone());
+//         let self_clone = self.clone();
+//
+//         for payload in payloads_arc.iter() {
+//             // let self_clone = Arc::clone(&self_clone); // Clone self for each iteration
+//             let tx_clone = tx.clone();
+//
+//             let payload_clone = payload.clone(); // Clone the individual payload
+//
+//             tokio::spawn(async move {
+//                 // match self_clone.control_device(payload_clone).await {
+//                 match self_clone.control_device(payload_clone).await {
+//                     Ok(_) => {
+//                         // Send a message to the receiver indicating success
+//                         if tx_clone.send(Ok(())).await.is_err() {
+//                             eprintln!("Failed to send result to the receiver");
+//                         }
+//                     }
+//                     Err(err) => {
+//                         // Send an error message to the receiver
+//                         if tx_clone.send(Err(err)).await.is_err() {
+//                             eprintln!("Failed to send result to the receiver");
+//                         }
+//                     }
+//                 }
+//             });
+//         }
+//
+//         // Collect and handle results
+//         let mut errors = vec![];
+//         for _ in 0..payloads_arc.len() {
+//             match rx.recv().await.unwrap() {
+//                 Ok(_) => {}
+//                 Err(err) => errors.push(err),
+//             }
+//         }
+//
+//         if errors.is_empty() {
+//             Ok(())
+//         } else {
+//             Err(GoveeClientError::new(errors))
+//         }
+//     }
+// }
 
 /// Controls a Govee appliance using the provided payload.
 ///

--- a/src/structs/govee.rs
+++ b/src/structs/govee.rs
@@ -92,14 +92,14 @@ pub struct ColorTemRange {
     pub max: i16,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize)]
 pub struct PayloadBody {
     pub device: String,
     pub model: String,
     pub cmd: GoveeCommand,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize)]
 pub struct GoveeCommand {
     pub name: String,
     pub value: String,

--- a/src/structs/govee.rs
+++ b/src/structs/govee.rs
@@ -92,14 +92,14 @@ pub struct ColorTemRange {
     pub max: i16,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct PayloadBody {
     pub device: String,
     pub model: String,
     pub cmd: GoveeCommand,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct GoveeCommand {
     pub name: String,
     pub value: String,


### PR DESCRIPTION
Adding a new method called `bulk_control_devices` that accepts `Vec[PayloadBody]`. It works like `control_device` but allow for async execution of multiple calls to govee api.