### PR TITLE
Publish to crates.io on every merge to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: coverage
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+jobs:
+  test:
+    name: publish
+    runs-on: ubuntu-latest
+    container:
+      image: xd009642/tarpaulin:develop-nightly
+      options: --security-opt seccomp=unconfined
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - name: publish to crates.io
+        run: cargo publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,4 +21,6 @@ jobs:
           toolchain: nightly
           override: true
       - name: publish to crates.io
-        run: cargo publish
+        uses: katyo/publish-crates@v2
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,6 @@ name: coverage
 on:
   push:
     branches: ["main"]
-  pull_request:
-    branches: ["main"]
 jobs:
   test:
     name: publish

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,5 @@ jobs:
         with:
           toolchain: nightly
           override: true
-      - uses: actions/checkout@v3
       - name: Build
         run: cargo build --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "govee-api"
 authors = ["Maciej Gierada"]
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["govee", "api", "wrapper", "client", "sdk"]


### PR DESCRIPTION
Adding workflow to publish `govee-api` crate to crates.io on every merge to main.